### PR TITLE
Expose the Bridging Header for use in Swift projects

### DIFF
--- a/AppCenterXCUITestExtensions.xcodeproj/project.pbxproj
+++ b/AppCenterXCUITestExtensions.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		F52543D21FB32B3800BD517A /* AppCenterXCUITestExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 895C8FA81E4DE27B0094FCE4 /* AppCenterXCUITestExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F52543D31FB32B3D00BD517A /* ACTLaunch.h in Headers */ = {isa = PBXBuildFile; fileRef = F556B1691F625FE500F949A6 /* ACTLaunch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F52543D41FB32B4200BD517A /* ACTLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 895C8FA61E4DE27B0094FCE4 /* ACTLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F52543D51FB32B4800BD517A /* AppCenterXCUITestExtensions-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 893607961E9539F0006F2956 /* AppCenterXCUITestExtensions-Bridging-Header.h */; };
+		F52543D51FB32B4800BD517A /* AppCenterXCUITestExtensions-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 893607961E9539F0006F2956 /* AppCenterXCUITestExtensions-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F5810D711F6038D800996525 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F5810D701F6038D800996525 /* AppDelegate.m */; };
 		F5810D741F6038D800996525 /* CircleController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5810D731F6038D800996525 /* CircleController.m */; };
 		F5810D771F6038D800996525 /* SquareController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5810D761F6038D800996525 /* SquareController.m */; };

--- a/Sources/AppCenterXCUITestExtensions.h
+++ b/Sources/AppCenterXCUITestExtensions.h
@@ -1,3 +1,5 @@
 
 #import "ACTLaunch.h"
 #import "ACTLabel.h"
+
+#import "AppCenterXCUITestExtensions-Bridging-Header.h"


### PR DESCRIPTION
The bridging header was both missing from the umbrella header, and set
to "project" rather than "public", restricting its use in pure Swift
targets.